### PR TITLE
fix: reset API version to wip on main (fixes #21)

### DIFF
--- a/code/API_definitions/subscription-status.yaml
+++ b/code/API_definitions/subscription-status.yaml
@@ -68,7 +68,7 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 
-  version: 0.1.0
+  version: wip
 
   x-camara-commonalities: 0.6
   license:
@@ -78,7 +78,7 @@ externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/SubscriptionStatus
 servers:
-  - url: "{apiRoot}/subscription-status/v0.1"
+  - url: "{apiRoot}/subscription-status/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/subscription-status.feature
+++ b/code/Test_definitions/subscription-status.feature
@@ -1,8 +1,8 @@
-Feature: CAMARA SubscriptionStatus API, v0.1.0 - Retrieve subscription status of a phone number
+Feature: CAMARA SubscriptionStatus API, vwip - Retrieve subscription status of a phone number
 
   Background: Common setup
     Given an environment at "apiRoot"
-    And the resource "/subscription-status/v0.1/retrieve-subscription-status"
+    And the resource "/subscription-status/vwip/retrieve-subscription-status"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Resets API version information on `main` to `wip` after the previous release, per the standard CAMARA post-release procedure.

This is a mandatory prerequisite for the Release Automation roll-out: the framework requires `wip` / `vwip` versions on `main` so the release process can drive transitions to concrete versions on dedicated release branches.

Two files updated, four lines:

- `code/API_definitions/subscription-status.yaml`: `info.version` `0.1.0` → `wip`; server URL `v0.1` → `vwip`
- `code/Test_definitions/subscription-status.feature`: line 1 Feature header `v0.1.0` → `vwip`; line 5 resource URL `v0.1` → `vwip`

#### Which issue(s) this PR fixes:

Fixes #21

#### Special notes for reviewers:

Mechanical wip reset. No semantic changes.

#### Changelog input

```
 release-note
Reset API version on main to wip (post-release procedure).
```

#### Additional documentation

This section can be blank.

```
docs

```
