### PR TITLE
release-plan.yaml correction for rc: target_release_tag from r2.0 to r2.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.0
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release


### PR DESCRIPTION
#### What type of PR is this?

* subproject management
* correction

#### What this PR does / why we need it:

* Previous update of the release-plan.yaml for the subscription status release candidate preparation had the wrong target_release_tag r2.0, which needs to be corrected to r2.1 by this PR.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

N/A - no upstream issue.

#### Special notes for reviewers:

N/A

#### Changelog input

```
 release-note
 None

```

#### Additional documentation 

```
docs
None

```
